### PR TITLE
fix(bigquery): use JSON_QUERY_ARRAY in array_size macro

### DIFF
--- a/models/macros.yaml
+++ b/models/macros.yaml
@@ -15,7 +15,7 @@ macros:
       - column_name
     value: "
       {% if warehouse.DatabaseType() == \"bigquery\" %}
-        array_length( split({{column_name}}) )
+        array_length( json_query_array({{column_name}}) )
       {% elif warehouse.DatabaseType() == \"redshift\" %}
         get_array_length( json_parse({{column_name}}) )
       {% elif warehouse.DatabaseType() == \"databricks\" %}


### PR DESCRIPTION
## What this PR changes

One-line fix on BigQuery in the `array_size` macro (`models/macros.yaml`):

```diff
       {% if warehouse.DatabaseType() == "bigquery" %}
-        array_length( split({{column_name}}) )
+        array_length( json_query_array({{column_name}}) )
       {% elif warehouse.DatabaseType() == "redshift" %}
```

Other warehouse branches (Redshift, Databricks, Snowflake, Postgres) are unchanged.

## Why

`SPLIT(<string>)` on BigQuery splits text on the default `,` delimiter. For a column whose value is a JSON array string (e.g. `[{"sku":"a","price":"1.0"},{"sku":"b"}]`) the comma split crosses element boundaries and returns a meaningless token count; for a JSON-typed column the implicit text cast returns NULL.

`JSON_QUERY_ARRAY` is the BigQuery-native function that extracts a JSON array as `ARRAY<STRING>` with one element per actual JSON element, so `ARRAY_LENGTH` counts correctly. Works for both `STRING`- and `JSON`-typed columns.

## Effect on downstream

`array_size` is called from exactly one entity_var — `avg_units_per_transaction`. Before this fix it was NULL for every user on BigQuery. After the fix it matches Snowflake's value for all 35 test users in WHT's integration fixture.

## Verification

End-to-end via WHT integration suite, with the package pinned at `schema_84_beta3` (cut from this PR's HEAD `c9f6be6`):

- `TestRunShopifyFeatures` on BigQuery: PASS. `AVG_UNITS_PER_TRANSACTION` column is now stable on BQ ↔ SF.
- Snowflake / Postgres / Redshift / Databricks: no behavior change — non-BQ branches of the macro are untouched.

## Tags cut from this branch

- `schema_84_beta3` — current HEAD (`c9f6be6`), the ship candidate.
- `schema_84_beta1`, `schema_84_beta2` — earlier exploratory tags from a Databricks-cast attempt that was reverted off this branch (see history note below). Kept for the record; do not use.

## Scope note: out-of-scope Databricks numeric divergence

This branch briefly carried two additional commits (`ce7a419`, `65621de`) attempting to fix Databricks numeric-precision drift via per-warehouse `CAST(.. AS DOUBLE)` / `CAST(.. AS NUMERIC(38, 18))` macros. They were reverted off this branch after end-to-end testing showed they swapped one cross-warehouse rendering divergence (Snowflake IEEE-754 drift, e.g. `214.07999999999998`) for another (Databricks trailing-zero rendering, e.g. `214.080000000000000000`), with `LAST_CART_VALUE_IN_DOLLARS` regressing from matching-on-both-warehouses to differing.

That divergence is fundamental to how the two warehouses serialize their numeric types and is being handled WHT-side, not in this package — see [rudderlabs/wht#2491](https://github.com/rudderlabs/wht/pull/2491) for the short-term per-warehouse `ColumnsToCompare` exclusion and the planned long-term numeric-canonicalization normalizer in the WHT comparator.